### PR TITLE
add Q&A infrastructure

### DIFF
--- a/src/header.tex
+++ b/src/header.tex
@@ -260,6 +260,9 @@
 
 %%% xsim settings
 
+\RequirePackage{xsim}
+\RequirePackage{needspace}
+
 \DeclareExerciseEnvironmentTemplate{QRef}
 {%
     \par\vspace{\baselineskip}

--- a/src/header.tex
+++ b/src/header.tex
@@ -296,7 +296,9 @@
 }
 
 \xsimsetup{%
-    print-solutions/headings-template=simple
+  path = {questions},
+  file-extension = {aux},
+  print-solutions/headings-template=simple
 }
 
 \AtEndDocument{\pagebreak\printsolutions}

--- a/src/header.tex
+++ b/src/header.tex
@@ -302,4 +302,4 @@
     print-solutions/headings-template=simple
 }
 
-\AtEndDocument{\printsolutions}
+\AtEndDocument{\pagebreak\printsolutions}

--- a/src/header.tex
+++ b/src/header.tex
@@ -265,20 +265,14 @@
     \par\vspace{\baselineskip}
     \Needspace*{2\baselineskip}
     \noindent
-    \hyperref[sol:\ExerciseID]{
-        \textbf{\XSIMmixedcase{\GetExerciseName}
-        ~\GetExerciseProperty{counter}}
-    }
+    \hyperref[sol:\ExerciseID]{\textbf{\XSIMmixedcase{\GetExerciseName}~\GetExerciseProperty{counter}}}
     \label{ques:\ExerciseID}
 }{}
 
 \DeclareExerciseEnvironmentTemplate{ARef}{%
         \Needspace*{2\baselineskip}
         \noindent
-        \hyperref[ques:\ExerciseID]{
-            \textbf{\XSIMmixedcase{\GetExerciseParameter{exercise-name}}
-            ~\GetExerciseProperty{counter}}
-        }
+        \hyperref[ques:\ExerciseID]{\textbf{\XSIMmixedcase{\GetExerciseParameter{exercise-name}}~\GetExerciseProperty{counter}}}
         \label{sol:\ExerciseID}
         \GetExerciseBody{exercise}
         \newline

--- a/src/header.tex
+++ b/src/header.tex
@@ -1,3 +1,5 @@
+\RequirePackage{mathtools}
+
 %%% BLACKBOARD SYMBOLS
 
 % hyperref package defines C and G, undefined to avoid conflicts
@@ -26,6 +28,8 @@
 \newcommand{\QRp}{\ensuremath{\QR_{p}}}
 
 %%% THEOREM COMMANDS
+
+\RequirePackage{amsthm}
 
 \theoremstyle{plain}            % following are "theorem" style
 \newtheorem{theorem}{Theorem}[section]
@@ -94,7 +98,6 @@
 
 %%% "LEFT-RIGHT" PAIRS OF SYMBOLS
 
-%% NOTE: this requires \usepackage{mathtools} in the document preamble
 
 % inner product
 \DeclarePairedDelimiter\inner{\langle}{\rangle}
@@ -243,6 +246,8 @@
 \newcommand{\view}{\text{view}}
 
 %%% COMMANDS FOR LECTURES/HOMEWORKS
+
+\RequirePackage{fancyhdr}
 
 \newcommand{\lecheader}{%
   \chead{\large \textbf{Lecture \lecturenum\\\lecturetopic}}

--- a/src/header.tex
+++ b/src/header.tex
@@ -44,7 +44,6 @@
 \theoremstyle{remark}           % following are remark style
 \newtheorem{remark}[theorem]{Remark}
 \newtheorem{note}[theorem]{Note}
-\newtheorem{exercise}[theorem]{Exercise}
 
 % equation numbering style
 \numberwithin{equation}{section}
@@ -257,3 +256,50 @@
   \setlength{\headheight}{20pt}
   \setlength{\headsep}{16pt}
 }
+
+
+%%% xsim settings
+
+\DeclareExerciseEnvironmentTemplate{QRef}
+{%
+    \par\vspace{\baselineskip}
+    \Needspace*{2\baselineskip}
+    \noindent
+    \hyperref[sol:\ExerciseID]{
+        \textbf{\XSIMmixedcase{\GetExerciseName}
+        ~\GetExerciseProperty{counter}}
+    }
+    \label{ques:\ExerciseID}
+}{}
+
+\DeclareExerciseEnvironmentTemplate{ARef}{%
+        \Needspace*{2\baselineskip}
+        \noindent
+        \hyperref[ques:\ExerciseID]{
+            \textbf{\XSIMmixedcase{\GetExerciseParameter{exercise-name}}
+            ~\GetExerciseProperty{counter}}
+        }
+        \label{sol:\ExerciseID}
+        \GetExerciseBody{exercise}
+        \newline
+        \textbf{\XSIMmixedcase{\GetExerciseName}}
+}{\par\vspace{\baselineskip}}
+
+\DeclareExerciseHeadingTemplate{simple}{%
+    \section*{\XSIMmixedcase{\GetExerciseParameter{solution-name}s}}
+}
+
+\DeclareExerciseType{question}{%
+    exercise-env = question,
+    solution-env = answer,
+    exercise-name = Question,
+    solution-name = Answer,
+    exercise-template = QRef,
+    solution-template = ARef,
+}
+
+\xsimsetup{%
+    print-solutions/headings-template=simple
+}
+
+\AtEndDocument{\printsolutions}

--- a/src/lec01.tex
+++ b/src/lec01.tex
@@ -7,6 +7,8 @@
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
 \usepackage{mathtools}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 
 \input{header}
 

--- a/src/lec01.tex
+++ b/src/lec01.tex
@@ -4,11 +4,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype,pdfsync}
-\usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{mathtools}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
+\usepackage{amssymb}
 
 \input{header}
 

--- a/src/lec01.tex
+++ b/src/lec01.tex
@@ -383,6 +383,7 @@ to completely ``randomize'' the message, but in a reversible way
   proof.
 \end{proof}
 
+
 \end{document}
 
 %%% Local Variables: 

--- a/src/lec02.tex
+++ b/src/lec02.tex
@@ -4,11 +4,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype,pdfsync}
-\usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{mathtools}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
+\usepackage{amssymb}
 \usepackage{algorithm,algorithmic}
 
 \input{header}

--- a/src/lec02.tex
+++ b/src/lec02.tex
@@ -7,6 +7,8 @@
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
 \usepackage{mathtools}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 \usepackage{algorithm,algorithmic}
 
 \input{header}

--- a/src/lec03.tex
+++ b/src/lec03.tex
@@ -6,6 +6,8 @@
 \usepackage{hyperref,microtype,pdfsync}
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 \usepackage{mathtools}
 \usepackage{algorithm,algorithmic}
 

--- a/src/lec03.tex
+++ b/src/lec03.tex
@@ -4,11 +4,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype,pdfsync}
-\usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
-\usepackage{mathtools}
+\usepackage{amssymb}
 \usepackage{algorithm,algorithmic}
 
 \input{header}

--- a/src/lec04.tex
+++ b/src/lec04.tex
@@ -6,6 +6,8 @@
 \usepackage{hyperref,microtype,pdfsync}
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 \usepackage{mathtools}
 \usepackage{algorithm,algorithmic}
 

--- a/src/lec04.tex
+++ b/src/lec04.tex
@@ -4,11 +4,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype,pdfsync}
-\usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
-\usepackage{mathtools}
+\usepackage{amssymb}
 \usepackage{algorithm,algorithmic}
 
 \input{header}

--- a/src/lec05.tex
+++ b/src/lec05.tex
@@ -4,11 +4,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype,pdfsync}
-\usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{mathtools}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
+\usepackage{amssymb}
 \usepackage{algorithm,algorithmic}
 
 \input{header}

--- a/src/lec05.tex
+++ b/src/lec05.tex
@@ -7,6 +7,8 @@
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
 \usepackage{mathtools}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 \usepackage{algorithm,algorithmic}
 
 \input{header}

--- a/src/lec06.tex
+++ b/src/lec06.tex
@@ -4,11 +4,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype,pdfsync}
-\usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{mathtools}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
+\usepackage{amssymb}
 \usepackage{algorithm,algorithmic}
 \usepackage{graphicx}
 \input{header}

--- a/src/lec06.tex
+++ b/src/lec06.tex
@@ -7,6 +7,8 @@
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
 \usepackage{mathtools}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 \usepackage{algorithm,algorithmic}
 \usepackage{graphicx}
 \input{header}

--- a/src/lec08.tex
+++ b/src/lec08.tex
@@ -7,6 +7,8 @@
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
 \usepackage{mathtools}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 \usepackage{graphicx}
 \usepackage{algorithm,algorithmic}
 

--- a/src/lec08.tex
+++ b/src/lec08.tex
@@ -4,11 +4,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype,pdfsync}
-\usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{mathtools}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
+\usepackage{amssymb}
 \usepackage{graphicx}
 \usepackage{algorithm,algorithmic}
 

--- a/src/lec09.tex
+++ b/src/lec09.tex
@@ -7,6 +7,8 @@
 \usepackage{amsmath,amsfonts,amssymb,amsthm,graphicx}
 \usepackage{mathtools}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 
 \input{header}
 

--- a/src/lec09.tex
+++ b/src/lec09.tex
@@ -4,11 +4,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype}
-\usepackage{amsmath,amsfonts,amssymb,amsthm,graphicx}
-\usepackage{mathtools}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
+\usepackage{amssymb,graphicx}
 
 \input{header}
 

--- a/src/lec10.tex
+++ b/src/lec10.tex
@@ -7,6 +7,8 @@
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
 \usepackage{mathtools}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 
 \input{header}
 

--- a/src/lec10.tex
+++ b/src/lec10.tex
@@ -4,11 +4,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype,pdfsync}
-\usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{mathtools}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
+\usepackage{amssymb}
 
 \input{header}
 

--- a/src/lec11.tex
+++ b/src/lec11.tex
@@ -7,6 +7,8 @@
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
 \usepackage{mathtools}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 
 \input{header}
 

--- a/src/lec11.tex
+++ b/src/lec11.tex
@@ -4,11 +4,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype,pdfsync}
-\usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{mathtools}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
+\usepackage{amssymb}
 
 \input{header}
 

--- a/src/lec12.tex
+++ b/src/lec12.tex
@@ -7,6 +7,8 @@
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
 \usepackage{mathtools}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 
 \input{header}
 

--- a/src/lec12.tex
+++ b/src/lec12.tex
@@ -4,11 +4,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype,pdfsync}
-\usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{mathtools}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
+\usepackage{amssymb}
 
 \input{header}
 

--- a/src/lec13.tex
+++ b/src/lec13.tex
@@ -5,11 +5,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype,pdfsync}
-\usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{mathtools}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
+\usepackage{amssymb}
 
 \input{header}
 

--- a/src/lec13.tex
+++ b/src/lec13.tex
@@ -8,6 +8,8 @@
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
 \usepackage{mathtools}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 
 \input{header}
 

--- a/src/lec14.tex
+++ b/src/lec14.tex
@@ -4,11 +4,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype,pdfsync}
-\usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{mathtools}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
+\usepackage{amssymb}
 
 \usepackage[noend]{algorithmic}
 \usepackage{algorithm}

--- a/src/lec14.tex
+++ b/src/lec14.tex
@@ -7,6 +7,8 @@
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
 \usepackage{mathtools}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 
 \usepackage[noend]{algorithmic}
 \usepackage{algorithm}

--- a/src/lec15.tex
+++ b/src/lec15.tex
@@ -7,6 +7,8 @@
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
 \usepackage{mathtools}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 
 \input{header}
 

--- a/src/lec15.tex
+++ b/src/lec15.tex
@@ -4,11 +4,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype,pdfsync}
-\usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{mathtools}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
+\usepackage{amssymb}
 
 \input{header}
 

--- a/src/lec16.tex
+++ b/src/lec16.tex
@@ -4,11 +4,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype,pdfsync}
-\usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
-\usepackage{mathtools}
+\usepackage{amssymb}
 \usepackage{algorithmic}
 
 \input{header}

--- a/src/lec16.tex
+++ b/src/lec16.tex
@@ -6,6 +6,8 @@
 \usepackage{hyperref,microtype,pdfsync}
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 \usepackage{mathtools}
 \usepackage{algorithmic}
 

--- a/src/lec17.tex
+++ b/src/lec17.tex
@@ -6,6 +6,8 @@
 \usepackage{hyperref,microtype,pdfsync}
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 \usepackage{mathtools}
 \usepackage[noend]{algorithm,algorithmic}
 

--- a/src/lec17.tex
+++ b/src/lec17.tex
@@ -4,11 +4,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype,pdfsync}
-\usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
-\usepackage{mathtools}
+\usepackage{amssymb}
 \usepackage[noend]{algorithm,algorithmic}
 
 \input{header}

--- a/src/lec18.tex
+++ b/src/lec18.tex
@@ -7,6 +7,8 @@
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
 \usepackage{mathtools}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 
 \input{header}
 

--- a/src/lec18.tex
+++ b/src/lec18.tex
@@ -4,11 +4,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype,pdfsync}
-\usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{mathtools}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
+\usepackage{amssymb}
 
 \input{header}
 

--- a/src/lec20.tex
+++ b/src/lec20.tex
@@ -5,11 +5,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype,pdfsync}
-\usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{mathtools}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
+\usepackage{amssymb}
 
 \input{header}
 

--- a/src/lec20.tex
+++ b/src/lec20.tex
@@ -8,6 +8,8 @@
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
 \usepackage{mathtools}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 
 \input{header}
 

--- a/src/lec21.tex
+++ b/src/lec21.tex
@@ -5,11 +5,7 @@
 \usepackage{newtxtext}
 \usepackage[T1]{fontenc}
 \usepackage{hyperref,microtype,pdfsync}
-\usepackage{amsmath,amsfonts,amssymb,amsthm}
-\usepackage{mathtools}
-\usepackage{fancyhdr}
-\usepackage{xsim}
-\usepackage{needspace}
+\usepackage{amssymb}
 
 \input{header}
 

--- a/src/lec21.tex
+++ b/src/lec21.tex
@@ -8,6 +8,8 @@
 \usepackage{amsmath,amsfonts,amssymb,amsthm}
 \usepackage{mathtools}
 \usepackage{fancyhdr}
+\usepackage{xsim}
+\usepackage{needspace}
 
 \input{header}
 


### PR DESCRIPTION
This PR adds the question and answer stuff via xsim as we discussed. 

To use it you just do:

```
\begin{question}
    ...
\end{question}

\begin{answer}
    ...
\end{answer}
```
and that's it.

The `answer` environment may be used anywhere in the document, it doesn't change where the answers are printed (though obviously where you place it relative to the positions of other answers changes which questions they'll correspond to).

This is what the questions look like in-place:

![Screenshot from 2020-07-24 17-35-31](https://user-images.githubusercontent.com/3654575/88437710-068f3c80-cdd5-11ea-8dbd-56532ca20da4.png)

(Pay no mind to the red rectangle. It's how my PDF viewer displays internal references)

And then here's the section automatically inserted at the end of the file if the `answer` environment is used anywhere.

![Screenshot from 2020-07-24 17-36-09](https://user-images.githubusercontent.com/3654575/88437938-91703700-cdd5-11ea-89c9-86aba628a94b.png)

(The questions and answers pictured are not included in this PR)
