### PR TITLE
Fix double Feistel distinguisher example lec09

### DIFF
--- a/src/lec09.tex
+++ b/src/lec09.tex
@@ -123,13 +123,21 @@ function (see Figure~\ref{fig:feistel_2_pic})?
 Unfortunately, two Feistel rounds also does not yield a PRP family.
 Consider arbitrary $L_1, L_2, R \in \bit^n$ with $L_{1} \neq L_{2}$,
 and any function $f : \bit^n \rightarrow \bit^n$.  We have
-$\textsc{Right}( D_f(L_1,R) ) = L_1\oplus f(R) $ and
-$\textsc{Right}(D_f(L_2,R) ) = L_2\oplus f(R)$.  Taking the
-exclusive-or of both equations, we get \[ \textsc{Right}( D_f(L_1,R))
-\oplus \textsc{Right}( D_f(L_2,R)) = L_1 \oplus L_2. \] On the other
+$\textsc{Left}(D_g( D_f(L_1,R) )) = \textsc{Right}( D_f(L_1,R) )$
+$= L_1\oplus f(R)$ and $\textsc{Left}(D_g( D_f(L_2,R) )) = $
+$\textsc{Right}( D_f(L_2,R) )= L_2\oplus f(R)$. Taking the 
+exlusive-or of both equations, we get 
+\begin{align*}
+\textsc{Left}(D_g( D_f(L_1,R) ) \oplus D_g( D_f(L_2,R) )) &=
+\textsc{Left}(D_g( D_f(L_1,R) ))\oplus\textsc{Left}(D_g( D_f(L_2,R) ))\\
+&= (L_1\oplus f(R)) \oplus (L_2\oplus f(R))\\
+&= L_1 \oplus L_2.
+\end{align*}
+On the other 
 hand, for a truly random permutation $\mathcal P$, $\mathcal P(L_1,R)
 \oplus \mathcal P(L_2, R)$ is the exclusive-or of two distinct random
-strings and its left half would equal $L_1\oplus L_2$ with only
+strings and $\textsc{Left}(\mathcal P(L_1,R)
+\oplus \mathcal P(L_2, R))$ would equal $L_1\oplus L_2$ with only
 negligible probability.
 
 Fortunately, all is not lost: we have the following theorem of Luby


### PR DESCRIPTION
I believe the proposed distinguisher for the double Feistel construction should look at the left half of the XOR of two output strings (instead of the right half). Since with two Feistel rounds, the L'' XOR L'' = R' XOR R' = (L1 XOR f(R)) XOR (L2 XOR f(R)) = L1 XOR L2, so we should be looking at the left half of the XOR of two distinct random strings.